### PR TITLE
Day forecast component

### DIFF
--- a/src/components/dayForecast/dayForecast.css
+++ b/src/components/dayForecast/dayForecast.css
@@ -1,0 +1,19 @@
+.dayForecast h3 {
+  font-size: 0.875rem;
+}
+
+.dayForecast p {
+  font-size: 1.5rem;
+}
+
+.dayForecast {
+  border-top: 1px solid rgb(222, 226, 230);
+}
+
+@media only screen and (min-width: 768px) {
+  .dayForecast {
+    border-top: none;
+    border-right: 1px solid rgb(222, 226, 230);
+    height: 142px;
+  }
+}

--- a/src/components/dayForecast/dayForecast.test.tsx
+++ b/src/components/dayForecast/dayForecast.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import partlyCloudyIcon from "../../media/partlyCloudy.png";
+import thunderstormsIcon from "../../media/thunderstorms.png";
+import rainIcon from "../../media/rain.png";
+import drizzleIcon from "../../media/drizzle.png";
+import DayForecast from "./dayForecast";
+
+describe("<DayForecast />", () => {
+  test("renders correct day, icon, and temp", () => {
+    render(
+      <DayForecast
+        forecast={{
+          temp: 93,
+          icon: partlyCloudyIcon,
+          date: 1665014400,
+          condition: "Partly Cloudy",
+        }}
+      />
+    );
+
+    const day = screen.getByText(/wed/i);
+    const temp = screen.getByText(/93°/i);
+    const weatherIcon = screen.getByAltText(/partly cloudy/i);
+
+    expect(day).toBeInTheDocument();
+    expect(temp).toBeInTheDocument();
+    expect(weatherIcon).toBeInTheDocument();
+  });
+
+  test("renders thunderstorms icon", () => {
+    render(
+      <DayForecast
+        forecast={{
+          temp: 32,
+          icon: thunderstormsIcon,
+          date: 1665129400,
+          condition: "Thunderstorms",
+        }}
+      />
+    );
+
+    const temp = screen.getByText(/32°/i);
+    const weatherIcon = screen.getByAltText(/thunderstorms/i);
+
+    expect(temp).toBeInTheDocument();
+    expect(weatherIcon).toBeInTheDocument();
+  });
+
+  test("renders rain icon", () => {
+    render(
+      <DayForecast
+        forecast={{
+          temp: 65,
+          icon: rainIcon,
+          date: 1665129400,
+          condition: "Rain",
+        }}
+      />
+    );
+
+    const weatherIcon = screen.getByAltText(/rain/i);
+
+    expect(weatherIcon).toBeInTheDocument();
+  });
+
+  test("renders drizzle icon", () => {
+    render(
+      <DayForecast
+        forecast={{
+          temp: 65,
+          icon: drizzleIcon,
+          date: 1665129400,
+          condition: "Drizzle",
+        }}
+      />
+    );
+
+    const weatherIcon = screen.getByAltText(/drizzle/i);
+
+    expect(weatherIcon).toBeInTheDocument();
+  });
+});

--- a/src/components/dayForecast/dayForecast.tsx
+++ b/src/components/dayForecast/dayForecast.tsx
@@ -1,0 +1,31 @@
+import "./dayForecast.css";
+
+type DailyForecast = {
+  temp: number;
+  icon: string;
+  date: number;
+  condition: string;
+};
+
+type DayForecastProps = {
+  forecast: DailyForecast;
+};
+
+const DayForecast = (props: DayForecastProps): JSX.Element => {
+  const weekdays = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const date = new Date(props.forecast.date * 1000);
+  const day = weekdays[date.getDay()];
+  return (
+    <section className="dayForecast d-flex flex-md-column align-items-center justify-content-around p-1">
+      <h3 className="fw-bold mb-0 mb-md-3">{day}</h3>
+      <img
+        src={props.forecast.icon}
+        alt={props.forecast.condition}
+        className="mb-md-3"
+      />
+      <p className="mb-0">{props.forecast.temp}°</p>
+    </section>
+  );
+};
+
+export default DayForecast;


### PR DESCRIPTION
Created the individual day forecast component. This component displays the day, weather icon, and temperature for a single day. Font-sizes, font-weights, and component height were pulled from the Figma sketch.

The component takes a single forecast object prop containing temp, icon, date, and condition. Date is a UNIX time number that is then converted to shortened day syntax.

Custom CSS was used to responsively adjust borders to ensure no doubling up.

Testing was done with Jest and React Testing Library.

<img width="729" alt="image" src="https://user-images.githubusercontent.com/86170323/194185934-26435c22-e546-4216-9d5d-e933b0136906.png">

In addition, the component is fully responsive.

<img width="340" alt="image" src="https://user-images.githubusercontent.com/86170323/194185973-efd8d211-2e1d-45c4-a9e4-e66bdf54654e.png">

