### PR TITLE
Change validator function to accept spaces, periods, and dashes

### DIFF
--- a/src/components/searchBar/searchBar.tsx
+++ b/src/components/searchBar/searchBar.tsx
@@ -17,7 +17,7 @@ const SearchBar = (props: SearchBarProps) => {
     if (
       validator.isEmpty(input) ||
       !validator.isLength(input, { min: 1, max: 50 }) ||
-      !validator.isAlpha(input)
+      !validator.matches(input, /^[a-zA-Z .-]+$/i)
     ) {
       setInputValid(false);
     } else {
@@ -53,7 +53,7 @@ const SearchBar = (props: SearchBarProps) => {
           }}
         />
         <Form.Text className="text-light">
-          Input can only consist of letters
+          Input can only consist of letters, periods, and dashes
         </Form.Text>
       </Form.Group>
       <Button


### PR DESCRIPTION
Change validator function to accept spaces, periods, and dashes in addition to lowercase and uppercase letters. This will allow cities such as St. Louis to be successfully input. This was implemented through a regular expression using Validator.

Previously only alpha characters were accepted.